### PR TITLE
オプショナルリンクが有効なブログと無効なブログが混在してTOPなどの新着がある時に、設定値が引き継がれてしまう不具合の対応

### DIFF
--- a/Event/OptionalLinkHelperEventListener.php
+++ b/Event/OptionalLinkHelperEventListener.php
@@ -221,6 +221,8 @@ class OptionalLinkHelperEventListener extends BcHelperEventListener {
 		if ($this->judgeBlogArchivesUrl) {
 			$this->modelInitializer($View);
 			if (!$this->optionalLinkConfigs['OptionalLinkConfig']['status']) {
+				// 設定値を初期化
+				$this->optionalLink = null;
 				// オプショナルリンク設定が無効の場合はURL書き換えを行わない
 				return;
 			}


### PR DESCRIPTION
よろしくお願いします！